### PR TITLE
Side panel change with data summary link

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <app-brand-bar></app-brand-bar>
-<app-data-summary *ngIf="dataSelected" (openSidePanel)="openSidePanel = true"></app-data-summary>
-<app-side-panel *ngIf="openSidePanel" ></app-side-panel>
+<app-data-summary *ngIf="dataSelected" [count]="count" (openSidePanel)="openSidePanel = true" (labelClicked)="showPanel($event)"></app-data-summary>
+<app-side-panel (countChanged)="updateCount($event)" (updated)="onUpdate()" *ngIf="openSidePanel" class="side-panel" [label]="clickedLabel" (panelClosed)="onPanelClosed()" ></app-side-panel>
 <app-report-page  *ngIf="dataSelected"></app-report-page>
 <app-footer (dataSelector)="[dataSelected=$event]"></app-footer>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+
 
 @Component({
   selector: 'app-root',
@@ -6,8 +8,9 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'Discover';
-  dataSelected = false;
+  title = 'Project_demo';
+  buttonVisible = true;
+  dataSelected = true;
   openSidePanel = false;
   clickedLabel = '';
 
@@ -15,4 +18,24 @@ export class AppComponent {
     this.clickedLabel = label;
     this.openSidePanel = true;
   }
+  onLabelClick(label: string): void {
+    this.clickedLabel = label;
+  }
+  // isPanelOpen = true;
+
+  onPanelClosed(): void {
+    this.openSidePanel = false;
+    console.log("close triggered");
+  }
+  count = 0;
+
+updateCount(newCount: number): void {
+  this.count = newCount;
+  console.log("appsidebar",this.count);
+}
+onUpdate(): void {
+
+}
+
+
 }

--- a/src/app/data-summary/data-summary.component.ts
+++ b/src/app/data-summary/data-summary.component.ts
@@ -12,10 +12,10 @@ export class DataSummaryComponent {
   sharedDataSummary: string[] = [];
   prefixList: string[] = [];
   jsondata: any;
-
+  data: any;
   currentIndex!: number;
   currentLabel!: string;
-  data: any;
+  @Input() count!: number;
 
 
   constructor(private http: HttpClient,) {
@@ -41,6 +41,20 @@ export class DataSummaryComponent {
     });
   }
 
+  @Input() itemAdded!: any;
+  updatecount(): void {
+    if (this.count === 0) {
+      this.sharedDataSummary[this.currentIndex] = "select"
+    }
+    else {
+      this.sharedDataSummary[this.currentIndex] = this.count.toString() + (" ") + this.currentLabel;
+    }
+    console.log(this.count);
+    console.log(this.itemAdded);
+  }
+  ngOnChanges(changes: SimpleChanges) {
+    this.updatecount();
+  }
   isClicked = false;
   @Output() openSidePanel = new EventEmitter<boolean>();
   @Output() labelClicked = new EventEmitter<string>();


### PR DESCRIPTION
Side panel now has Close button, and after clicking + button it open in 2nd page (pending to add back on second page),
data changes on data-summary after adding or removing from the side-panel